### PR TITLE
feat(store): add first manifests into this repo

### DIFF
--- a/store/README.md
+++ b/store/README.md
@@ -1,0 +1,4 @@
+# Store
+
+The Warp store includes a series of manifests for prebuilt artifacts that are
+publicly accessible and can be installed directly.

--- a/store/tricorder/beam/manifest.json
+++ b/store/tricorder/beam/manifest.json
@@ -1,0 +1,19 @@
+{
+  "published_at": "2023-03-01T21:09:32+00:00",
+  "keys": {
+    "aarch64-unknown-linux-gnu": [
+      "59d899297a16269a3034573bb67cf33c97c96ddbe825ef67467655b63e86b11a",
+      "aa6221089e9b02d42b6283125cc495811d8237c63558b566033f81ee83e3ed7d",
+      "ebca734d2503c794c64a7d078f6a2023ace4ce70aca37c882e7ee6b0a57ca86c",
+      "06016bc66dfc5d9a1b05074ee6f4ad4cf191da57ba43a4167a39cc02ab31b876"
+    ],
+    "x86_64-unknown-linux-gnu": [],
+    "aarch64-apple-darwin": [
+      "47c6ebd325e550935e43af5e1948a623b142c946251a4f6038403c1b53ed5fe8",
+      "0410a5377e99c674d5649ebb895680fc77bd3bfe54005a1da4b16c9abbca25e2",
+      "d335ea86d12bce62398a73b7ab3f04fa2d1b5ad808537b43c492fa87d95a6a92",
+      "69ee8b77f4fa632c41309fa11ea75f24613689d1f307776175c44dc948d85f29"
+    ],
+    "x86_64-apple-darwin": []
+  }
+}

--- a/store/tricorder/rust/manifest.json
+++ b/store/tricorder/rust/manifest.json
@@ -1,0 +1,9 @@
+{
+  "published_at": "2023-03-01T21:09:32+00:00",
+  "keys": {
+    "aarch64-unknown-linux-gnu": [
+      "6c6b409e9f3e03acf384e82185620369c469e5efd24a58810a362b8cbddb3a77"
+    ],
+    "aarch64-apple-darwin": []
+  }
+}


### PR DESCRIPTION
Maintaining these manifests in a separate repo has become troublesome in the last few weeks of iterating across the different tricorders. Putting them into the same repo allows us to also read them _directly from disk_ during development.