### PR TITLE
fix(reporter): correct nr of caches and tests

### DIFF
--- a/core/events/event.rs
+++ b/core/events/event.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::model::SourceKind;
+use crate::model::{SourceKind, TaskId};
 use crate::{CacheStatus, Goal, Target};
 use url::Url;
 
@@ -127,6 +127,7 @@ pub enum WorkerEvent {
     },
     TargetBuildCompleted {
         goal: Goal,
+        task_id: TaskId,
         target: Target,
         signature: String,
         cache_status: CacheStatus,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -28,7 +28,7 @@ pub(crate) mod workspace;
 
 pub use config::*;
 pub use drive::*;
-pub use model::{CacheStatus, Goal, Target};
+pub use model::{CacheStatus, Goal, Target, TaskId};
 
 #[macro_use]
 extern crate derive_builder;

--- a/core/worker/local/worker.rs
+++ b/core/worker/local/worker.rs
@@ -253,6 +253,7 @@ where
             .send(WorkerEvent::TargetBuildCompleted {
                 target: (*target).clone(),
                 goal,
+                task_id: *task.clone().id(),
                 cache_status,
                 signature: signature.name().to_string(),
             });


### PR DESCRIPTION
Using TaskId instead of Targets to get a proper count of goal+target+signature. 